### PR TITLE
Feature/arguments

### DIFF
--- a/Sources/SociableWeaver/Enumerations/CaseStyleOption.swift
+++ b/Sources/SociableWeaver/Enumerations/CaseStyleOption.swift
@@ -11,6 +11,7 @@ import Foundation
 public enum CaseStyleOption {
     case lowercase
     case uppercase
+    case capitalized
     case camelCase
     case pascalCase
     case snakeCase

--- a/Sources/SociableWeaver/Enumerations/RequestType.swift
+++ b/Sources/SociableWeaver/Enumerations/RequestType.swift
@@ -5,6 +5,7 @@
 //  Created by Nicholas Bellucci on 11/29/19.
 //
 
+/// The possible request types that can be made.
 public enum RequestType: String, RawRepresentable {
     case query
     case mutation

--- a/Sources/SociableWeaver/Extensions/Array+Argument.swift
+++ b/Sources/SociableWeaver/Extensions/Array+Argument.swift
@@ -6,6 +6,7 @@
 //
 
 extension Array where Element == Argument {
+    /// The GraphQL Representation of an arguments array
     var graphQLRepresentable: String {
         var components: [String] = []
 

--- a/Sources/SociableWeaver/Extensions/Array+Argument.swift
+++ b/Sources/SociableWeaver/Extensions/Array+Argument.swift
@@ -1,0 +1,18 @@
+//
+//  Array+Argument.swift
+//  
+//
+//  Created by Nicholas Bellucci on 12/6/19.
+//
+
+extension Array where Element == Argument {
+    var graphQLRepresentable: String {
+        var components: [String] = []
+
+        forEach {
+            components.append("\($0.key): \($0.value.argumentValue)")
+        }
+
+        return components.joined(separator: ", ")
+    }
+}

--- a/Sources/SociableWeaver/Extensions/String+Utils.swift
+++ b/Sources/SociableWeaver/Extensions/String+Utils.swift
@@ -27,6 +27,8 @@ internal extension String {
             return self.lowercased()
         case .uppercase:
             return self.uppercased()
+        case .capitalized:
+            return self.capitalized
         case .camelCase:
             return self.camelCased()
         case .pascalCase:

--- a/Sources/SociableWeaver/Extensions/String+Utils.swift
+++ b/Sources/SociableWeaver/Extensions/String+Utils.swift
@@ -43,7 +43,9 @@ internal extension String {
 
 fileprivate extension String {
     /// Determines if a character is uppercase.
-    var isUppercase: Bool { return String(self).uppercased() == String(self) }
+    var isUppercase: Bool {
+        String(self).uppercased() == String(self)
+    }
 
     /// A string array of words that were capitalized in a string
     var capitalizedWords: [String]? {

--- a/Sources/SociableWeaver/FunctionBuilders/ObjectBuilder.swift
+++ b/Sources/SociableWeaver/FunctionBuilders/ObjectBuilder.swift
@@ -9,15 +9,11 @@ import Foundation
 
 @_functionBuilder
 internal struct ObjectBuilder {
-    static func buildBlock(_ children: CustomStringConvertible...) -> String {
+    static func buildBlock(_ children: Weavable...) -> String {
         var descriptions: [String] = []
 
         children.forEach {
-            if let value = $0 as? CodingKey {
-                descriptions.append(value.stringValue)
-            } else if let value = $0 as? Object {
-                descriptions.append(String(describing: value))
-            }
+            descriptions.append(String(describing: $0))
         }
 
         return descriptions.joined(separator: " ")

--- a/Sources/SociableWeaver/FunctionBuilders/ObjectBuilder.swift
+++ b/Sources/SociableWeaver/FunctionBuilders/ObjectBuilder.swift
@@ -10,12 +10,6 @@ import Foundation
 @_functionBuilder
 internal struct ObjectBuilder {
     static func buildBlock(_ children: Weavable...) -> String {
-        var descriptions: [String] = []
-
-        children.forEach {
-            descriptions.append(String(describing: $0))
-        }
-
-        return descriptions.joined(separator: " ")
+        children.map { String(describing: $0) }.joined(separator: " ")
     }
 }

--- a/Sources/SociableWeaver/Helpers/Field.swift
+++ b/Sources/SociableWeaver/Helpers/Field.swift
@@ -1,0 +1,61 @@
+//
+//  Field.swift
+//  
+//
+//  Created by Nicholas Bellucci on 12/6/19.
+//
+
+public struct Field {
+    public let name: String
+    public var alias: String? = nil
+    public var arguments: [Argument]? = nil
+
+    public init(_ type: Any.Type, caseStyleOption: CaseStyleOption = .lowercase, alias: String? = nil, arguments: [Argument]? = nil) {
+        self.name = String(describing: type).convert(with: caseStyleOption)
+        self.alias = alias
+        self.arguments = arguments
+    }
+
+    public init(_ key: CodingKey, alias: String? = nil, arguments: [Argument]? = nil) {
+        self.name = key.stringValue
+        self.alias = alias
+        self.arguments = arguments
+    }
+}
+
+extension Field: Weavable {
+    public var description: String {
+        buildDescription()
+    }
+
+    public var debugDescription: String {
+        buildDescription()
+    }
+}
+
+private extension Field {
+    func formatField(_ name: String, alias: String) -> String {
+        return "\(alias): \(name)"
+    }
+
+    func formatField(_ name: String, arguments: [Argument]) -> String {
+        return "\(name)(\(arguments.graphQLRepresentable))"
+    }
+
+    func formatField(_ name: String, alias: String, arguments: [Argument]) -> String {
+        return "\(alias): \(name)(\(arguments.graphQLRepresentable))"
+    }
+
+    func buildDescription() -> String {
+        switch(alias, arguments) {
+        case let(.some(alias), .some(arguments)):
+            return formatField(name, alias: alias, arguments: arguments)
+        case let(.some(alias), nil):
+            return formatField(name, alias: alias)
+        case let(nil, .some(arguments)):
+            return formatField(name, arguments: arguments)
+        default:
+            return name
+        }
+    }
+}

--- a/Sources/SociableWeaver/Helpers/Field.swift
+++ b/Sources/SociableWeaver/Helpers/Field.swift
@@ -52,18 +52,34 @@ extension Field: Weavable {
 }
 
 private extension Field {
+    /**
+    Formats a field with a name and alias.
+
+     Example `newPost: post`
+     */
     func formatField(_ name: String, alias: String) -> String {
         return "\(alias): \(name)"
     }
 
+    /**
+    Formats a field with a name and arguments.
+
+     Example `post(id: 1)`
+     */
     func formatField(_ name: String, arguments: [Argument]) -> String {
         return "\(name)(\(arguments.graphQLRepresentable))"
     }
 
+    /**
+    Formats a field with a name, alias, and arguments.
+
+     Example `newPost: post(id: 1)`
+     */
     func formatField(_ name: String, alias: String, arguments: [Argument]) -> String {
         return "\(alias): \(name)(\(arguments.graphQLRepresentable))"
     }
 
+    /// Determines which format is needed based on the parameters provided on initialization.
     func buildDescription() -> String {
         switch(alias, arguments) {
         case let(.some(alias), .some(arguments)):

--- a/Sources/SociableWeaver/Helpers/Field.swift
+++ b/Sources/SociableWeaver/Helpers/Field.swift
@@ -5,6 +5,18 @@
 //  Created by Nicholas Bellucci on 12/6/19.
 //
 
+/**
+`Field` is a model consisting of a name, possible alias, and possible arguments
+
+ `Field.name`
+ The name of the object that will be returned.
+
+ `Field.alias`
+ An optional value that defines the alias name of the field.
+
+ `Field.arguments`
+ An optional value that consists of all some/all passable arguments for the field.
+*/
 public struct Field {
     public let name: String
     public var alias: String? = nil
@@ -23,6 +35,12 @@ public struct Field {
     }
 }
 
+/**
+Field conforms to Weavable in order to provide a description as well as a debugDescription of the object model in question.
+
+ Example `String(describing: field)`: `newPost: post(id: 1)`
+ Example `String(reflecting: field)`: `newPost: post(id: 1)`
+ */
 extension Field: Weavable {
     public var description: String {
         buildDescription()

--- a/Sources/SociableWeaver/Helpers/Field.swift
+++ b/Sources/SociableWeaver/Helpers/Field.swift
@@ -58,7 +58,7 @@ private extension Field {
      Example `newPost: post`
      */
     func formatField(_ name: String, alias: String) -> String {
-        return "\(alias): \(name)"
+        "\(alias): \(name)"
     }
 
     /**
@@ -67,7 +67,7 @@ private extension Field {
      Example `post(id: 1)`
      */
     func formatField(_ name: String, arguments: [Argument]) -> String {
-        return "\(name)(\(arguments.graphQLRepresentable))"
+        "\(name)(\(arguments.graphQLRepresentable))"
     }
 
     /**
@@ -76,7 +76,7 @@ private extension Field {
      Example `newPost: post(id: 1)`
      */
     func formatField(_ name: String, alias: String, arguments: [Argument]) -> String {
-        return "\(alias): \(name)(\(arguments.graphQLRepresentable))"
+        "\(alias): \(name)(\(arguments.graphQLRepresentable))"
     }
 
     /// Determines which format is needed based on the parameters provided on initialization.

--- a/Sources/SociableWeaver/Helpers/Object.swift
+++ b/Sources/SociableWeaver/Helpers/Object.swift
@@ -15,12 +15,12 @@
  The aggregated fields that make up the object.
 */
 public struct Object {
-    public let name: String
-    public let fields: String
+    public let field: Field
+    public let fieldAggregates: String
 
-    private init(_ name: String, fields: String) {
-        self.name = name
-        self.fields = fields
+    private init(_ field: Field, fieldAggregates: String) {
+        self.field = field
+        self.fieldAggregates = fieldAggregates
     }
 }
 
@@ -31,85 +31,25 @@ Object conforms to CustomStringConvertible as well as CustomDebugStringConvertib
  Example `String(describing: object)`: `post { id title content }`
  Example `String(reflecting: object)`: `post { id title content }`
  */
-extension Object: CustomStringConvertible, CustomDebugStringConvertible {
+extension Object: Weavable {
     public var description: String {
-        name.withSubfields(fields)
+        String(describing: field).withSubfields(fieldAggregates)
     }
 
     public var debugDescription: String {
-        name.withSubfields(fields)
+        String(describing: field).withSubfields(fieldAggregates)
     }
 }
 
 public extension Object {
     /**
     Object initializer using the object function builder.
-     This initializer accepts a type which will be converted to a string representation and used as the name.
-
-    - parameter type: The object type to be converted.
-    - parameter caseStyleOption: The case style for the converted type string.
-    - parameter content: The object builder accepts structs/classes conforming to `CustomStringConvertable`.
-    */
-    init(_ type: Any.Type, caseStyleOption: CaseStyleOption = .lowercase, @ObjectBuilder _ content: () -> String) {
-        let name = String(describing: type).convert(with: caseStyleOption)
-        self.init(name, fields: content())
-    }
-
-    /**
-    Workaround for function builders not accepting one element yet due to it still being a prototype.
-     TODO - Remove when functionBuilders are fully implemented.
-
-     Object initializer using the object function builder.
-     This initializer accepts a type which will be converted to a string representation and used as the name.
-
-    - parameter type: The object type to be converted.
-    - parameter caseStyleOption: The case style for the converted type string.
-    - parameter content: The object builder accepts structs/classes conforming to `CustomStringConvertable`.
-    */
-    init(_ type: Any.Type, caseStyleOption: CaseStyleOption = .lowercase, _ content: () -> CustomStringConvertible) {
-        let name = String(describing: type).convert(with: caseStyleOption)
-        var stringRepresentation: String = ""
-
-        if let value = content() as? CodingKey {
-            stringRepresentation = value.stringValue
-        } else if let value = content() as? Object {
-            stringRepresentation = value.fields
-        }
-
-        self.init(name, fields: stringRepresentation)
-    }
-
-    /**
-    Object initializer using the object function builder.
      This initializer accepts a coding key which will be used as the name.
 
     - parameter key: The coding key to be used.
     - parameter content: The object builder accepts structs/classes conforming to `CustomStringConvertable`.
     */
-    init(_ key: CodingKey, @ObjectBuilder _ content: () -> String) {
-        let name = key.stringValue
-        self.init(name, fields: content())
-    }
-
-    /**
-    Workaround for function builders not accepting one element yet due to it still being a prototype.
-     TODO - Remove when functionBuilders are fully implemented.
-
-     This initializer accepts a coding key which will be used as the name.
-
-    - parameter key: The coding key to be used.
-    - parameter content: The closure returning a `CustomStringConvertible`.
-    */
-    init(_ key: CodingKey, _ content: () -> CustomStringConvertible) {
-        let name = key.stringValue
-        var stringRepresentation: String = ""
-
-        if let value = content() as? CodingKey {
-            stringRepresentation = value.stringValue
-        } else if let value = content() as? Object {
-            stringRepresentation = value.fields
-        }
-
-        self.init(name, fields: stringRepresentation)
+    init(_ field: Field, @ObjectBuilder _ content: () -> String) {
+        self.init(field, fieldAggregates: content())
     }
 }

--- a/Sources/SociableWeaver/Helpers/Object.swift
+++ b/Sources/SociableWeaver/Helpers/Object.swift
@@ -8,10 +8,10 @@
 /**
 `Object` is a model consisting of a name and description.
 
- `Object.name`
- The name of the object that will be returned.
+ `Object.field`
+ The parent field of the object.
 
- `Object.fields`
+ `Object.fieldAggregates`
  The aggregated fields that make up the object.
 */
 public struct Object {
@@ -25,8 +25,7 @@ public struct Object {
 }
 
 /**
-Object conforms to CustomStringConvertible as well as CustomDebugStringConvertible in order to provide
- a description as well as a debugDescription of the object model in question.
+Object conforms to Weavable in order to provide a description as well as a debugDescription of the object model in question.
 
  Example `String(describing: object)`: `post { id title content }`
  Example `String(reflecting: object)`: `post { id title content }`
@@ -47,7 +46,7 @@ public extension Object {
      This initializer accepts a coding key which will be used as the name.
 
     - parameter key: The coding key to be used.
-    - parameter content: The object builder accepts structs/classes conforming to `CustomStringConvertable`.
+    - parameter content: The object builder accepts structs/classes conforming to `Weavable`.
     */
     init(_ field: Field, @ObjectBuilder _ content: () -> String) {
         self.init(field, fieldAggregates: content())

--- a/Sources/SociableWeaver/Protocols/Argument.swift
+++ b/Sources/SociableWeaver/Protocols/Argument.swift
@@ -1,0 +1,100 @@
+//
+//  File.swift
+//  
+//
+//  Created by Nicholas Bellucci on 12/6/19.
+//
+
+public protocol ArgumentValueRepresentable {
+    var argumentValue: String { get }
+}
+
+public typealias Argument = (key: String, value: ArgumentValueRepresentable)
+
+extension Bool: ArgumentValueRepresentable {
+    public var argumentValue: String {
+        return "\(self)"
+    }
+}
+
+extension String: ArgumentValueRepresentable {
+    public var argumentValue: String {
+        return "\"\(self)\""
+    }
+}
+
+extension Int: ArgumentValueRepresentable {
+    public var argumentValue: String {
+        return "\(self)"
+    }
+}
+
+extension Double: ArgumentValueRepresentable {
+    public var argumentValue: String {
+        return "\(self)"
+    }
+}
+
+extension Float: ArgumentValueRepresentable {
+    public var argumentValue: String {
+        return "\(self)"
+    }
+}
+
+extension Array: ArgumentValueRepresentable {
+    public var argumentValue: String  {
+        let params = map { value -> String in
+            if let value = value as? String {
+                return value.argumentValue
+            } else if let value = value as? Int {
+                return value.argumentValue
+            } else if let value = value as? Float {
+                return value.argumentValue
+            } else if let value = value as? Double {
+                return value.argumentValue
+            } else if let value = value as? Bool {
+                return value.argumentValue
+            } else if let value = value as? Array<Any> {
+                return value.argumentValue
+            } else if let value = value as? Dictionary<String, Any> {
+                return value.argumentValue
+            }
+
+            return ""
+        }
+
+        return "[\(params.joined(separator: ", "))]"
+    }
+}
+
+extension Dictionary: ArgumentValueRepresentable {
+    public var argumentValue: String  {
+        let params = map { (arg) -> String in
+            let (key, value) = arg
+
+            var argumentValue: String {
+                if let value = value as? String {
+                    return value.argumentValue
+                } else if let value = value as? Int {
+                    return value.argumentValue
+                } else if let value = value as? Float {
+                    return value.argumentValue
+                } else if let value = value as? Double {
+                    return value.argumentValue
+                } else if let value = value as? Bool {
+                    return value.argumentValue
+                } else if let value = value as? Array<Any> {
+                    return value.argumentValue
+                } else if let value = value as? Dictionary<String, Any> {
+                    return value.argumentValue
+                }
+
+                return ""
+            }
+
+            return "\(key): \(argumentValue)"
+        }
+
+        return "{\(params.joined(separator: ", "))}"
+    }
+}

--- a/Sources/SociableWeaver/Protocols/Argument.swift
+++ b/Sources/SociableWeaver/Protocols/Argument.swift
@@ -22,31 +22,31 @@ public protocol ArgumentValueRepresentable {
 
 extension Bool: ArgumentValueRepresentable {
     public var argumentValue: String {
-        return "\(self)"
+        "\(self)"
     }
 }
 
 extension String: ArgumentValueRepresentable {
     public var argumentValue: String {
-        return "\"\(self)\""
+        "\"\(self)\""
     }
 }
 
 extension Int: ArgumentValueRepresentable {
     public var argumentValue: String {
-        return "\(self)"
+        "\(self)"
     }
 }
 
 extension Double: ArgumentValueRepresentable {
     public var argumentValue: String {
-        return "\(self)"
+        "\(self)"
     }
 }
 
 extension Float: ArgumentValueRepresentable {
     public var argumentValue: String {
-        return "\(self)"
+        "\(self)"
     }
 }
 

--- a/Sources/SociableWeaver/Protocols/Argument.swift
+++ b/Sources/SociableWeaver/Protocols/Argument.swift
@@ -5,11 +5,20 @@
 //  Created by Nicholas Bellucci on 12/6/19.
 //
 
+/**
+ `Argument` is a type alias that defines a key value tuple.
+
+ This tuple provides a `String` and an `ArgumentValueRepresentable` which is
+ used to construct an argument for a field.
+ */
+public typealias Argument = (key: String, value: ArgumentValueRepresentable)
+
+/// A type that can be used as to represent an argument.
 public protocol ArgumentValueRepresentable {
+
+    /// The argument representation of a given value.
     var argumentValue: String { get }
 }
-
-public typealias Argument = (key: String, value: ArgumentValueRepresentable)
 
 extension Bool: ArgumentValueRepresentable {
     public var argumentValue: String {

--- a/Sources/SociableWeaver/Protocols/Weavable.swift
+++ b/Sources/SociableWeaver/Protocols/Weavable.swift
@@ -1,0 +1,8 @@
+//
+//  Weavable.swift
+//  
+//
+//  Created by Nicholas Bellucci on 12/6/19.
+//
+
+public protocol Weavable: CustomStringConvertible, CustomDebugStringConvertible { }

--- a/Sources/SociableWeaver/Protocols/Weavable.swift
+++ b/Sources/SociableWeaver/Protocols/Weavable.swift
@@ -5,4 +5,9 @@
 //  Created by Nicholas Bellucci on 12/6/19.
 //
 
+/**
+ A type that conforms to both `CustomStringConvertible` and `CustomDebugStringConvertible`.
+
+ Weavable is inherited by models that are used to construct a GraphQL query/mutation.
+ */
 public protocol Weavable: CustomStringConvertible, CustomDebugStringConvertible { }

--- a/Tests/SociableWeaverTests/SociableWeaverTests.swift
+++ b/Tests/SociableWeaverTests/SociableWeaverTests.swift
@@ -4,27 +4,51 @@ import XCTest
 final class SociableWeaverTests: XCTestCase {
     func testBasicQuery() {
         let query = Request(.query) {
-            Object(Post.self) {
-                Post.CodingKeys.title
-                Post.CodingKeys.content
-                Object(Post.CodingKeys.author) {
-                    Author.CodingKeys.id
-                    Author.CodingKeys.name
+            Object(Field(Post.self)) {
+                Field(Post.CodingKeys.title)
+                Field(Post.CodingKeys.content)
+
+                Object(Field(Post.CodingKeys.author)) {
+                    Field(Author.CodingKeys.id)
+                    Field(Author.CodingKeys.name)
                 }
-                Object(Post.CodingKeys.comments) {
-                    Comment.CodingKeys.id
-                    Object(Comment.CodingKeys.author) {
-                        Author.CodingKeys.name
+
+                Object(Field(Post.CodingKeys.comments)) {
+                    Field(Comment.CodingKeys.id)
+                    Object(Field(Comment.CodingKeys.author)) {
+                        Field(Author.CodingKeys.id)
+                        Field(Author.CodingKeys.name)
                     }
-                    Comment.CodingKeys.content
+                    Field(Comment.CodingKeys.content)
                 }
             }
         }
 
-        XCTAssertEqual(String(describing: query), "query { post { title content author { id name } comments { id author { name } content } } }")
+        let expected = "query { post { title content author { id name } comments { id author { id name } content } } }"
+        XCTAssertEqual(String(describing: query), expected)
+    }
+
+    func testQueryWithArguments() {
+        let query = Request(.query) {
+            Object(Field(Post.self)) {
+                Object(Field(Post.CodingKeys.author, alias: "newAuthor", arguments: [Argument(key: "id", value: 1)])) {
+                    Field(Author.CodingKeys.id)
+                    Field(Author.CodingKeys.name, arguments: [Argument(key: "value", value: "Nick")])
+                }
+
+                Object(Field(Post.CodingKeys.comments, alias: "newComments")) {
+                    Field(Comment.CodingKeys.id)
+                    Field(Comment.CodingKeys.content)
+                }
+            }
+        }
+
+        let expected = "query { post { newAuthor: author(id: 1) { id name(value: \"Nick\") } newComments: comments { id content } } }"
+        XCTAssertEqual(String(describing: query), expected)
     }
 
     static var allTests = [
         ("testBasicQuery", testBasicQuery),
+        ("testQueryWithArguments", testQueryWithArguments),
     ]
 }


### PR DESCRIPTION
Added a Field model that accepts a name, alias, and array of arguments to help build fields more effectively. I also had to remove ```init(_ field: Field, _ content: () -> CustomStringConvertible) {
        self.init(field, fieldAggregates: String(describing: content()))
    }``` which was accepting a single parameter instead of the function builder. This was causing issues that I would like to discuss to see if we can either resolve them or figure out a different direction to take.