### PR TITLE
Ensure deterministic results

### DIFF
--- a/Sources/SociableWeaver/Protocols/Argument.swift
+++ b/Sources/SociableWeaver/Protocols/Argument.swift
@@ -123,6 +123,6 @@ extension Dictionary: ArgumentValueRepresentable {
             return "\(key): \(argumentValue)"
         }
 
-        return "{\(params.joined(separator: ", "))}"
+        return "{\(params.sorted().joined(separator: ", "))}"
     }
 }

--- a/Tests/SociableWeaverTests/Models/Author.swift
+++ b/Tests/SociableWeaverTests/Models/Author.swift
@@ -1,13 +1,15 @@
 public struct Author: Codable {
     public enum CodingKeys: String, CodingKey, CaseIterable {
-        case id, name
+        case id, name, birthplace
     }
 
     public let id: String
     public let name: String
+    public let birthplace: [String: String]
 
-    public init(id: String, name: String) {
+    public init(id: String, name: String, birthplace: [String: String]) {
         self.id = id
         self.name = name
+        self.birthplace = birthplace
     }
 }

--- a/Tests/SociableWeaverTests/SociableWeaverGeneralTests.swift
+++ b/Tests/SociableWeaverTests/SociableWeaverGeneralTests.swift
@@ -9,6 +9,13 @@ final class SociableWeaverGeneralTests: XCTestCase {
                     Field(Author.CodingKeys.id)
                     Field(Author.CodingKeys.name)
                         .argument(key: "value", value: "AuthorName")
+                    Field(Author.CodingKeys.birthplace)
+                        .argument(key: "value", value: [
+                            "city": "New York",
+                            "state": "New York",
+                            "postalCode": "10001",
+                            "neighborhood": "Chelsea"
+                        ])
                 }
                 .alias("newAuthor")
                 .argument(key: "id", value: 1)
@@ -21,7 +28,7 @@ final class SociableWeaverGeneralTests: XCTestCase {
             }
         }
 
-        let expected = "query { post { newAuthor: author(id: 1) { id name(value: \"AuthorName\") } newComments: comments { id content } } }"
+        let expected = "query { post { newAuthor: author(id: 1) { id name(value: \"AuthorName\") birthplace(value: {city: \"New York\", neighborhood: \"Chelsea\", postalCode: \"10001\", state: \"New York\"}) } newComments: comments { id content } } }"
         XCTAssertEqual(String(describing: query), expected)
     }
 


### PR DESCRIPTION
Before this change, if a dictionary is passed in as an argument value, it'd serialize in a random order. This sorts them and ensures all results will be deterministic. I updated a test case to illustrate the bug.