### PR TITLE
Argument includeIfNil option

### DIFF
--- a/Sources/SociableWeaver/Helpers/Field.swift
+++ b/Sources/SociableWeaver/Helpers/Field.swift
@@ -68,9 +68,14 @@ public extension Field {
 
      - Parameter key: The key for the argument.
      - Parameter value: The value for the argument conforming to `ArgumentValueRepresentable`.
+     - Parameter includeIfNil: Boolean to determine if argument should be included when value is nil. Defaults to false.
      - Returns: A `Field` including the argument passed.
      */
-    func argument(key: String, value: ArgumentValueRepresentable?) -> Field {
+    func argument(key: String, value: ArgumentValueRepresentable, includeIfNil: Bool = false) -> Field {
+        if value.argumentValue == "null", includeIfNil == false {
+            return self
+        }
+        
         var copy = self
         let argument = Argument(key: key, value: value)
 

--- a/Sources/SociableWeaver/Helpers/Object/Object.swift
+++ b/Sources/SociableWeaver/Helpers/Object/Object.swift
@@ -86,9 +86,14 @@ public extension Object {
 
      - Parameter key: The key for the argument.
      - Parameter value: The value for the argument conforming to `ArgumentValueRepresentable`.
+     - Parameter includeIfNil: Boolean to determine if argument should be included when value is nil. Defaults to false.
      - Returns: An `Object` including the argument passed.
      */
-    func argument(key: String, value: ArgumentValueRepresentable) -> Object {
+    func argument(key: String, value: ArgumentValueRepresentable, includeIfNil: Bool = false) -> Object {
+        if value.argumentValue == "null", includeIfNil == false {
+            return self
+        }
+        
         var copy = self
         let argument = Argument(key: key, value: value)
 

--- a/Tests/SociableWeaverTests/SociableWeaverBuilderTests.swift
+++ b/Tests/SociableWeaverTests/SociableWeaverBuilderTests.swift
@@ -62,6 +62,21 @@ final class SociableWeaverBuilderTests: XCTestCase {
         XCTAssertEqual(String(describing: query), expected)
     }
     
+    func testBuildObjectWithNilArgument() {
+        let value: String? = nil
+        
+        let query = Weave(.query) {
+            Object(Post.self) {
+                Field(Author.CodingKeys.id)
+                Field(Author.CodingKeys.name)
+            }
+            .argument(key: "testArgument", value: value)
+        }
+
+        let expected = "query { post { id name } }"
+        XCTAssertEqual(String(describing: query), expected)
+    }
+    
     func testBuildObjectWithCaseStyle() {
         let query = Weave(.query) {
             Object(Post.self) {
@@ -226,6 +241,7 @@ final class SociableWeaverBuilderTests: XCTestCase {
         ("testBuildObjectWithAlias", testBuildObjectWithAlias),
         ("testBuildObjectWithSchemaName", testBuildObjectWithSchemaName),
         ("testBuildObjectWithArgument", testBuildObjectWithArgument),
+        ("testBuildObjectWithNilArgument", testBuildObjectWithNilArgument),
         ("testBuildObjectWithCaseStyle", testBuildObjectWithCaseStyle),
         ("testBuildObjectWithRemove", testBuildObjectWithFalseInclude),
         ("testBuildObjectWithTrueSkip", testBuildObjectWithTrueSkip),


### PR DESCRIPTION
Added includeIfNil feature to argument added on a field or object. This allows for the inclusion of null as the value for an argument if needed.