### PR TITLE
Update swift keyword @_functionBuilder to @resultBuilder (swift 5.4)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.4
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/SociableWeaver/FunctionBuilders/ObjectBuilder.swift
+++ b/Sources/SociableWeaver/FunctionBuilders/ObjectBuilder.swift
@@ -1,4 +1,4 @@
-@_functionBuilder
+@resultBuilder
 public struct ObjectBuilder {
     public static func buildBlock(_ children: ObjectWeavable...) -> String {
         var descriptions: [String] = []

--- a/Sources/SociableWeaver/FunctionBuilders/OperationBuilder.swift
+++ b/Sources/SociableWeaver/FunctionBuilders/OperationBuilder.swift
@@ -1,4 +1,4 @@
-@_functionBuilder
+@resultBuilder
 public struct OperationBuilder {
     public static func buildBlock(_ children: Weavable...) -> String {
         var weavables: [Weavable] = []


### PR DESCRIPTION
This is in order to remove compiler warnings